### PR TITLE
fix: 设置回溯历史功能上限为10

### DIFF
--- a/scripts/feed-roll-history-btn.js
+++ b/scripts/feed-roll-history-btn.js
@@ -6,6 +6,7 @@ chrome.storage.sync.get(
   (storage) => {
     if (storage["biliplus-enable"] && storage["feed-roll-history-btn"]) {
       const feedHistory = [];
+      const maxHistory = 10;
       let feedHistoryIndex = 0;
 
       const feedRollBackBtn = `
@@ -70,6 +71,9 @@ chrome.storage.sync.get(
               document.getElementsByClassName("feed-card")
             );
             feedHistory.push(feedCards);
+          }
+          if (feedHistory.length > maxHistory) {
+            feedHistory.shift();
           }
           feedHistoryIndex = feedHistory.length;
           disableElementById("feed-roll-back-btn", false);


### PR DESCRIPTION
避免长时间使用摇一摇按钮造成的内存占用，且需求上不太可能会需要记录全部浏览历史。