### PR TITLE
fix: Firefox compatibility - settings toggle and background scripts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,10 @@
     }
   ],
   "background": {
-    "service_worker": "scripts/background/api-listener.js"
+    "service_worker": "scripts/background/api-listener.js",
+    "scripts": [
+      "scripts/background/api-listener.js"
+    ]
   },
   "permissions": ["storage", "webRequest", "tabs"],
   "host_permissions": ["*://*.bilibili.com/x/player/wbi/v2"],

--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,19 @@
   },
   "content_scripts": [
     {
-      "js": ["scripts/common/utils.js", "scripts/feed-roll-history-btn.js", "scripts/clean-home-page.js"],
-      "matches": ["https://www.bilibili.com/*"],
-      "css": ["css/global.css", "css/feed-roll-history-btn.css", "css/clean-home-page.css"]
+      "js": [
+        "scripts/common/utils.js",
+        "scripts/feed-roll-history-btn.js",
+        "scripts/clean-home-page.js"
+      ],
+      "matches": [
+        "https://www.bilibili.com/*"
+      ],
+      "css": [
+        "css/global.css",
+        "css/feed-roll-history-btn.css",
+        "css/clean-home-page.css"
+      ]
     },
     {
       "js": [
@@ -23,13 +33,30 @@
         "scripts/hide-hot-search-list.js",
         "scripts/auto-subtitle.js"
       ],
-      "matches": ["https://*.bilibili.com/*"],
-      "css": ["css/global.css", "css/ai-conclusion.css"]
+      "matches": [
+        "https://*.bilibili.com/*"
+      ],
+      "css": [
+        "css/global.css",
+        "css/ai-conclusion.css"
+      ]
     },
     {
-      "js": ["scripts/common/utils.js", "scripts/common/bilibili-api.js", "scripts/hide-user-comment.js", "scripts/stepless-video-rate.js"],
-      "matches": ["https://www.bilibili.com/video/*", "https://www.bilibili.com/list/*", "https://www.bilibili.com/bangumi/play/*"],
-      "css": ["css/global.css", "css/stepless-video-rate-btn.css"]
+      "js": [
+        "scripts/common/utils.js",
+        "scripts/common/bilibili-api.js",
+        "scripts/hide-user-comment.js",
+        "scripts/stepless-video-rate.js"
+      ],
+      "matches": [
+        "https://www.bilibili.com/video/*",
+        "https://www.bilibili.com/list/*",
+        "https://www.bilibili.com/bangumi/play/*"
+      ],
+      "css": [
+        "css/global.css",
+        "css/stepless-video-rate-btn.css"
+      ]
     }
   ],
   "background": {
@@ -38,11 +65,26 @@
       "scripts/background/api-listener.js"
     ]
   },
-  "permissions": ["storage", "webRequest", "tabs"],
-  "host_permissions": ["*://*.bilibili.com/x/player/wbi/v2"],
+  "permissions": [
+    "storage",
+    "webRequest",
+    "tabs"
+  ],
+  "host_permissions": [
+    "*://*.bilibili.com/x/player/wbi/v2"
+  ],
   "action": {
     "default_popup": "settings/settings.html",
     "default_icon": "logo.png"
   },
-  "author": "timothy-lau@outlook.com"
+  "author": "timothy-lau@outlook.com",
+  "browser_specific_settings": {
+    "gecko": {
+      "data_collection_permissions": {
+        "required": [
+          "none"
+        ]
+      }
+    }
+  }
 }

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -2,7 +2,7 @@ $(function () {
   $('input[type=checkbox]').each(function () {
     let key = $(this).data('key');
     chrome.storage.sync.get(key, storage => {
-      $(this).attr('checked', storage[key]);
+      $(this).prop('checked', !!storage[key]);
     });
 
     $(this).change(() => {


### PR DESCRIPTION
## Changes

### 1. Fix settings toggle persistence
Changed jQuery checkbox initialization from \.attr('checked', ...)\ to \.prop('checked', !!...)\ in \settings.js\. The \.attr()\ method doesn't reliably update the visual state of checkboxes in modern jQuery (1.6+), causing toggles to appear in incorrect states.

### 2. Add background scripts array for Firefox MV3
Firefox's Manifest V3 implementation requires a \scripts\ array in the \ackground\ object alongside \service_worker\. Without this, the extension fails to load in Firefox with the error: *background.service_worker is currently disabled. Add background.scripts.*

Both changes are required for the extension to function correctly in Firefox.