### PR TITLE
fix(#165): fix backtrack buttons disappearing after SPA navigation

### DIFF
--- a/scripts/feed-roll-history-btn.js
+++ b/scripts/feed-roll-history-btn.js
@@ -18,11 +18,10 @@ chrome.storage.sync.get(['biliplus-enable', 'feed-roll-history-btn'], storage =>
     </button>
 `;
 
-    const targetNode = document.querySelector('.recommended-container_floor-aside');
-    const disconnect = _UTILS.observe(targetNode, () => {
+    _UTILS.observe(document.body, () => {
       let feedRollBtn = document.getElementsByClassName('roll-btn')[0];
 
-      if (feedRollBtn) {
+      if (feedRollBtn && feedRollBtn.id !== 'feed-roll-btn') {
         // 处理返回上一页feed的历史内容
         let backBtn = document.createElement('button');
         feedRollBtn.parentNode.appendChild(backBtn);
@@ -76,9 +75,6 @@ chrome.storage.sync.get(['biliplus-enable', 'feed-roll-history-btn'], storage =>
             disableElementById('feed-roll-next-btn', true);
           });
         });
-
-        // disconnect observer
-        disconnect();
       }
     });
   }


### PR DESCRIPTION
Fixes #165

## Problem
The backtrack (previous/next) buttons for the homepage refresh feature disappear after SPA navigation (e.g., going from a video page back to the homepage by clicking the Bilibili logo).

## Root Cause
1. The \MutationObserver\ was attached to \.recommended-container_floor-aside\, which gets destroyed and recreated during SPA navigation.
2. The observer called \disconnect()\ immediately after the first successful button injection, making it unable to detect subsequent DOM rebuilds.

## Fix
1. Changed observation target from \.recommended-container_floor-aside\ to \document.body\, which persists across all SPA transitions.
2. Removed the \disconnect()\ call so the observer stays active.
3. Added a guard check \eedRollBtn.id !== 'feed-roll-btn'\ to prevent duplicate injection.