### PR TITLE
feat: add option to hide non-video recommendations from homepage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
   },
   "content_scripts": [
     {
-      "js": ["scripts/common/utils.js", "scripts/feed-roll-history-btn.js", "scripts/clean-home-page.js"],
+      "js": ["scripts/common/utils.js", "scripts/feed-roll-history-btn.js", "scripts/clean-home-page.js",
+        "scripts/hide-non-video-rcmd.js"],
       "matches": ["https://www.bilibili.com/*"],
       "css": ["css/global.css", "css/feed-roll-history-btn.css", "css/clean-home-page.css"]
     },

--- a/scripts/hide-non-video-rcmd.js
+++ b/scripts/hide-non-video-rcmd.js
@@ -1,0 +1,45 @@
+/**
+ * 屏蔽首页非视频推荐 (直播/番剧/综艺/课堂/广告)
+ */
+chrome.storage.sync.get(['biliplus-enable', 'hide-non-video-rcmd'], storage => {
+    if (storage['biliplus-enable'] && storage['hide-non-video-rcmd']) {
+        const disconnect = _UTILS.observe(document.body, () => {
+            // 匹配 .bili-video-card, 旧版 .feed-card, 直播卡片 .bili-live-card, 以及番剧/综艺/电影专属的 .floor-single-card
+            const cards = document.querySelectorAll('.bili-video-card, .feed-card, .bili-live-card, .floor-single-card');
+
+            cards.forEach(card => {
+                // 如果已经被隐藏，跳过以节省性能
+                if (card.style.display === 'none') return;
+
+                // 直播卡片和 floor-single-card（番剧/综艺/电影/漫画/赛事）直接隐藏
+                if (card.classList.contains('bili-live-card') || card.classList.contains('floor-single-card')) {
+                    card.style.display = 'none';
+                    return;
+                }
+
+                const linkElem = card.querySelector('a');
+                const link = linkElem ? linkElem.href : '';
+                const badgeElem = card.querySelector('.bili-video-card__badge, .bili-video-card__info--badge, .bili-video-card__info--ad');
+                const badgeText = badgeElem ? badgeElem.innerText : '';
+                const isAdClass = card.querySelector('.bili-video-card__info--ad') !== null;
+
+                // 有些直播或者赛事卡片的文字会写在 bottom 区块里
+                const bottomElem = card.querySelector('.bili-video-card__info--bottom');
+                const bottomText = bottomElem ? bottomElem.innerText : '';
+
+                const isNonVideo =
+                    link.includes('live.bilibili.com') ||
+                    link.includes('bangumi/play') ||
+                    link.includes('cheese/play') ||
+                    link.includes('cm.bilibili.com') ||
+                    isAdClass ||
+                    (badgeText && badgeText.match(/直播|番剧|国创|综艺|电影|课堂|广告|纪录片|电视剧|动画/)) ||
+                    (bottomText && bottomText.match(/直播|赛事/));
+
+                if (isNonVideo) {
+                    card.style.display = 'none';
+                }
+            });
+        });
+    }
+});

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -59,6 +59,10 @@
           <input type="checkbox" class="toggle" data-key="feed-roll-history-btn" />
         </label>
         <label class="label cursor-pointer">
+          <span class="label-text">屏蔽首页的直播/番剧/综艺等非视频推荐</span>
+          <input type="checkbox" class="toggle" data-key="hide-non-video-rcmd" />
+        </label>
+        <label class="label cursor-pointer">
           <span class="label-text">开启视频封面 AI 总结</span>
           <input type="checkbox" class="toggle" data-key="ai-conclusion" />
         </label>


### PR DESCRIPTION
## New Feature
Adds a new toggleable option to hide non-video content (live streams, anime/bangumi, variety shows, movies, manga, esports, and ads) from the Bilibili homepage recommendation feed.

### How it works
A \MutationObserver\ on \document.body\ continuously monitors new feed cards. Cards are identified as non-video and hidden (\display: none\) based on:
- **CSS class**: \.bili-live-card\ and \.floor-single-card\ are always non-video containers
- **Link URL**: \live.bilibili.com\, \angumi/play\, \cheese/play\, \cm.bilibili.com\
- **Badge text**: matching keywords like \直播\, \番剧\, \综艺\, \电影\, \广告\, etc.

Regular videos whose titles happen to contain these keywords are NOT affected, as only badge/info elements are checked, not the video title.

### Files changed
- **[NEW]** \scripts/hide-non-video-rcmd.js\ - Core filtering logic
- **[MODIFIED]** \manifest.json\ - Register the new script
- **[MODIFIED]** \settings/settings.html\ - Add toggle switch