### PR TITLE
fix: AI Conclusion Bug

### DIFF
--- a/scripts/common/bilibili-api.js
+++ b/scripts/common/bilibili-api.js
@@ -358,7 +358,12 @@ class _BILIAPI {
    */
   static async getAIConclusion(params) {
     const query = await _UTILS.getwts(params);
-    const response = await fetch(`${_BILIAPI.BILIBILI_API}/x/web-interface/view/conclusion/get?${query}`);
+    const response = await fetch(
+      `${_BILIAPI.BILIBILI_API}/x/web-interface/view/conclusion/get?${query}`,
+      {
+        credentials: "include"
+      }
+    );
     const jsonData = await response.json();
     if (response.status !== 200 || !jsonData) {
       throw new Error();


### PR DESCRIPTION
In my testing, _BILIAPI.BILIBILI_API/x/web-interface/view/conclusion/get requires cookies.
If credentials are not included , response 400 (not logged in).