### PR TITLE
feat: 集成 SnapVolume 音量滑块整五吸附功能

### DIFF
--- a/css/snap-volume.css
+++ b/css/snap-volume.css
@@ -1,0 +1,15 @@
+/* SnapVolume Toast */
+#sv-toast {
+  background: rgba(0, 0, 0, 0.75) !important;
+  color: #ffffff !important;
+  padding: 8px 16px !important;
+  border-radius: 6px !important;
+  font-size: 16px !important;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+  z-index: 2147483647 !important;
+  opacity: 1 !important;
+  transition: opacity 0.3s ease-out !important;
+  pointer-events: none !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3) !important;
+  display: block !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -21,10 +21,11 @@
         "scripts/cover-viewer.js",
         "scripts/ai-conclusion.js",
         "scripts/hide-hot-search-list.js",
-        "scripts/auto-subtitle.js"
+        "scripts/auto-subtitle.js",
+        "scripts/snap-volume.js"
       ],
       "matches": ["https://*.bilibili.com/*"],
-      "css": ["css/global.css", "css/ai-conclusion.css"]
+      "css": ["css/global.css", "css/ai-conclusion.css", "css/snap-volume.css"]
     },
     {
       "js": ["scripts/common/utils.js", "scripts/common/bilibili-api.js", "scripts/hide-user-comment.js", "scripts/stepless-video-rate.js"],

--- a/scripts/snap-volume.js
+++ b/scripts/snap-volume.js
@@ -1,0 +1,250 @@
+/**
+ * SnapVolume - 音量滑块整五吸附
+ */
+
+const STEP = 5;
+
+function snap(value, step = STEP) {
+  if (value <= 0) return 0;
+  return Math.ceil(value / step) * step;
+}
+
+function snapFloor(value, step = STEP) {
+  if (value <= 0) return 0;
+  return Math.floor(value / step) * step;
+}
+
+// ============ Toast ============
+
+let toastTimer = null;
+
+function showToast(value, video) {
+  const existing = document.getElementById('sv-toast');
+  if (existing) existing.remove();
+
+  const el = document.createElement('div');
+  el.id = 'sv-toast';
+  el.textContent = `\uD83D\uDD0A ${value}`;
+  el.setAttribute('role', 'status');
+
+  if (video) {
+    const rect = video.getBoundingClientRect();
+    el.style.cssText = `
+      position: fixed !important;
+      left: ${rect.left + rect.width / 2}px !important;
+      top: ${rect.top + rect.height / 2}px !important;
+      transform: translate(-50%, -50%) !important;
+      z-index: 2147483647 !important;
+    `;
+  } else {
+    el.style.cssText = `
+      position: fixed !important;
+      left: 50% !important;
+      top: 50% !important;
+      transform: translate(-50%, -50%) !important;
+      z-index: 2147483647 !important;
+    `;
+  }
+
+  document.body.appendChild(el);
+  el.offsetHeight;
+  el.style.opacity = '1';
+
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    el.style.opacity = '0';
+    setTimeout(() => el.remove(), 300);
+  }, 800);
+}
+
+// ============ VideoVolumeHook ============
+
+function hookVideoVolume(video) {
+  if (video._sv_hooked) return;
+  video._sv_hooked = true;
+
+  const descriptor = Object.getOwnPropertyDescriptor(HTMLVideoElement.prototype, 'volume');
+  if (!descriptor) return;
+
+  Object.defineProperty(video, 'volume', {
+    get() {
+      return descriptor.get.call(this);
+    },
+    set(newVal) {
+      const percent = newVal * 100;
+      const snappedPercent = snap(percent);
+      const snappedVal = snappedPercent / 100;
+
+      const currentPercent = descriptor.get.call(this) * 100;
+      if (Math.round(currentPercent) !== snappedPercent) {
+        descriptor.set.call(this, snappedVal);
+        setTimeout(() => {
+          updateBiliVolumeDisplay(snappedPercent);
+        }, 0);
+      }
+      return snappedVal;
+    },
+    configurable: true
+  });
+}
+
+function updateBiliVolumeDisplay(percent) {
+  const num = document.querySelector('.bpx-player-ctrl-volume-number');
+  if (num) num.textContent = percent;
+}
+
+// ============ 滑块拦截 ============
+
+function getClassName(el) {
+  let cls = el.className || '';
+  if (typeof cls !== 'string') cls = cls.baseVal || '';
+  return cls;
+}
+
+function isBiliVolumeSlider(el) {
+  if (!el) return false;
+  const cls = getClassName(el).toLowerCase();
+  return cls.includes('bpx-player-ctrl-volume-progress') || cls.includes('bui-slider');
+}
+
+function calcVolumeFromPointer(sliderEl, e) {
+  const rect = sliderEl.getBoundingClientRect();
+  const trackHeight = rect.height;
+  const pointerY = e.clientY - rect.top;
+  const percent = Math.max(0, Math.min(100, (1 - pointerY / trackHeight) * 100));
+  return Math.round(percent);
+}
+
+function initSliderInterceptor() {
+  let isDragging = false;
+  let currentSlider = null;
+  let lastSnapped = -1;
+
+  document.addEventListener('pointerdown', e => {
+    let el = e.target;
+    while (el && el !== document.body && el !== document.documentElement) {
+      if (isBiliVolumeSlider(el)) {
+        e.preventDefault();
+        isDragging = true;
+        currentSlider = el;
+        el.setPointerCapture(e.pointerId);
+        return;
+      }
+      el = el.parentElement;
+    }
+  }, true);
+
+  document.addEventListener('pointermove', e => {
+    if (!isDragging || !currentSlider) return;
+    if (e.buttons !== 1) return;
+
+    const percent = calcVolumeFromPointer(currentSlider, e);
+    const snapped = snap(percent);
+    if (snapped === lastSnapped) return;
+
+    lastSnapped = snapped;
+    const video = document.querySelector('video');
+    if (video) {
+      video.volume = snapped / 100;
+      updateBiliVolumeDisplay(snapped);
+      showToast(snapped, video);
+    }
+  }, true);
+
+  document.addEventListener('pointerup', () => {
+    isDragging = false;
+    currentSlider = null;
+    lastSnapped = -1;
+  }, true);
+
+  document.addEventListener('wheel', e => {
+    let el = e.target;
+    while (el && el !== document.body && el !== document.documentElement) {
+      if (isBiliVolumeSlider(el)) {
+        e.preventDefault();
+        e.stopPropagation();
+        const video = document.querySelector('video');
+        if (video) {
+          const current = Math.round(video.volume * 100);
+          let newVal;
+          if (e.deltaY < 0) {
+            newVal = snap(Math.min(100, current + STEP));
+          } else {
+            newVal = snapFloor(Math.max(0, current - STEP));
+          }
+          if (newVal === current) return;
+          video.volume = newVal / 100;
+          updateBiliVolumeDisplay(newVal);
+          showToast(newVal, video);
+        }
+        return;
+      }
+      el = el.parentElement;
+    }
+  }, { passive: false });
+
+  document.addEventListener('keydown', e => {
+    const key = e.key;
+    if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(key)) return;
+
+    let el = e.target;
+    while (el && el !== document.body && el !== document.documentElement) {
+      if (isBiliVolumeSlider(el)) {
+        e.preventDefault();
+        const video = document.querySelector('video');
+        if (!video) return;
+        const step = e.shiftKey ? 10 : STEP;
+        const current = Math.round(video.volume * 100);
+        let newVal;
+        if (key === 'ArrowUp' || key === 'ArrowRight') {
+          newVal = snap(Math.min(100, current + step));
+        } else {
+          newVal = snapFloor(Math.max(0, current - step));
+        }
+        if (newVal !== current) {
+          video.volume = newVal / 100;
+          updateBiliVolumeDisplay(newVal);
+          showToast(newVal, video);
+        }
+        return;
+      }
+      el = el.parentElement;
+    }
+  }, true);
+}
+
+// ============ VideoObserver ============
+
+function initVideoObserver() {
+  const hooked = new WeakSet();
+
+  function hookAllVideos() {
+    document.querySelectorAll('video').forEach(v => {
+      if (!hooked.has(v)) {
+        hooked.add(v);
+        hookVideoVolume(v);
+      }
+    });
+  }
+
+  hookAllVideos();
+  const observer = new MutationObserver(hookAllVideos);
+  observer.observe(document, { subtree: true, childList: true });
+}
+
+// ============ Init ============
+
+function init() {
+  chrome.storage.sync.get(['biliplus-enable', 'snap-volume'], storage => {
+    if (storage['biliplus-enable'] && storage['snap-volume']) {
+      initSliderInterceptor();
+      initVideoObserver();
+    }
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -75,6 +75,10 @@
           <input type="checkbox" class="toggle" data-key="hide-hot-search-list" />
         </label>
         <label class="label cursor-pointer">
+          <span class="label-text">开启音量滑块整五吸附</span>
+          <input type="checkbox" class="toggle" data-key="snap-volume" />
+        </label>
+        <label class="label cursor-pointer">
           <div class="tooltip tooltip-right tooltip-error" data-tip="谨慎使用！">
             <span class="label-text text-red-400">显示视频封面正在观看人数</span>
           </div>


### PR DESCRIPTION
## Summary

- 新增 `scripts/snap-volume.js` - 音量滑块整五吸附功能模块
- 新增 `css/snap-volume.css` - Toast 样式
- 在 `manifest.json` 中注册 content script 到 `https://*.bilibili.com/*`
- 在 `settings.html` 中添加开关（默认关闭）
- Toast 显示在视频中心位置
- 功能受总开关（`biliplus-enable`）和子开关（`snap-volume`）双重控制

## 来源

从独立插件 [SnapVolume](https://github.com/Sifen4K/SnapVolume) 集成，功能不变：音量滑块自动吸附到整五步进（0, 5, 10...100）

## 功能说明

- **鼠标拖动**：拖拽音量滑块时自动吸附到最近整五
- **滚轮支持**：鼠标滚轮在滑块上滚动时吸附到整五
- **键盘支持**：方向键可在滑块上以整五步进调节音量

## Test plan

- [ ] 加载扩展后默认关闭该功能
- [ ] 开启总开关后功能仍关闭（需单独开启）
- [ ] 开启子开关后鼠标拖动音量滑块吸附生效
- [ ] 滚轮操作音量滑块吸附生效
- [ ] Toast 显示在视频中心，不被控件遮挡
- [ ] 关闭开关后功能立即失效

🤖 Generated with [Claude Code](https://claude.com/claude-code)