### PR TITLE
fix: align stepless playback rate control and prevent hover dead zone

### DIFF
--- a/css/stepless-video-rate-btn.css
+++ b/css/stepless-video-rate-btn.css
@@ -1,13 +1,10 @@
 .stepless-video-rate-btn {
-  box-sizing: border-box;
   color: #fff;
   display: block !important;
   flex: 0 0 50px;
   font: 14px/22px -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica,
     Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
-  height: 32px;
   margin: 0;
-  padding: 10px 0 0;
   position: relative;
   text-align: center;
   width: 50px;
@@ -22,8 +19,6 @@
   cursor: pointer;
   font: inherit;
   font-weight: 600;
-  height: 22px;
-  line-height: 22px;
   outline: 0;
   padding: 0;
   user-select: none;
@@ -45,7 +40,9 @@
   background: rgba(20, 20, 20, 0.9);
   border: 0;
   border-radius: 2px;
-  bottom: 41px;
+  /* Keep the panel attached to the trigger so moving the pointer into it
+     does not cross a dead zone and repeatedly schedule hide/show timers. */
+  bottom: 100%;
   box-shadow: none;
   box-sizing: border-box;
   color: #fff;
@@ -205,21 +202,8 @@ body.biliplus-autoplay-ending-blocked .bpx-player-ending-related {
   .bpx-player-container[data-screen='full'] .stepless-video-rate-btn,
   .bpx-player-container[data-screen='web'] .stepless-video-rate-btn {
     font-size: 16px;
-    height: 43px;
-    padding-top: 11px;
-    line-height: 32px;
   }
 
-  .bpx-player-container[data-screen='full'] .stepless-video-rate-btn-result,
-  .bpx-player-container[data-screen='web'] .stepless-video-rate-btn-result {
-    height: 32px;
-    line-height: 32px;
-  }
-
-  .bpx-player-container[data-screen='full'] .stepless-video-rate-box,
-  .bpx-player-container[data-screen='web'] .stepless-video-rate-box {
-    bottom: 65px;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/scripts/stepless-video-rate.js
+++ b/scripts/stepless-video-rate.js
@@ -15,6 +15,9 @@
   const RATE_TRANSITION_GUARD_MS = 3200;
   const RATE_REAPPLY_DELAYS = [0, 80, 260, 800, 1800, 3000];
   const AUTOPLAY_MODES = new Set(['keep', 'off', 'playlist']);
+  const RATE_CONTROL_SELECTOR = '[data-biliplus-control="stepless-video-rate"]';
+  const NATIVE_RATE_BUTTON_SELECTOR =
+    `.bpx-player-ctrl-btn.bpx-player-ctrl-playbackrate:not(${RATE_CONTROL_SELECTOR})`;
 
   const STORAGE_KEYS = {
     master: 'biliplus-enable',
@@ -536,9 +539,15 @@
   function removeRateUi() {
     clearTimeout(state.hideRatePanelTimer);
     state.hideRatePanelTimer = null;
-    if (state.rateUi && state.rateUi.root.isConnected) state.rateUi.root.remove();
+    document.querySelectorAll(RATE_CONTROL_SELECTOR).forEach(root => root.remove());
     state.rateUi = null;
     document.body && document.body.classList.remove('biliplus-stepless-video-rate');
+  }
+
+  function removeDuplicateRateUis(keepRoot = null) {
+    document.querySelectorAll(RATE_CONTROL_SELECTOR).forEach(root => {
+      if (root !== keepRoot) root.remove();
+    });
   }
 
   function createRateUi(controlBar, nativeRateButton) {
@@ -657,18 +666,24 @@
 
     document.body && document.body.classList.add('biliplus-stepless-video-rate');
 
-    if (state.rateUi && state.rateUi.root.isConnected) {
+    const nativeRateButton = document.querySelector(NATIVE_RATE_BUTTON_SELECTOR);
+    const controlBar = nativeRateButton && nativeRateButton.parentElement;
+    if (!nativeRateButton || !controlBar) return;
+
+    if (
+      state.rateUi &&
+      state.rateUi.root.isConnected &&
+      state.rateUi.root.parentElement === controlBar
+    ) {
+      removeDuplicateRateUis(state.rateUi.root);
       updateRateUi(rateKeeper.getDesiredRate());
       return;
     }
 
     clearTimeout(state.hideRatePanelTimer);
     state.hideRatePanelTimer = null;
+    removeDuplicateRateUis();
     state.rateUi = null;
-    const nativeRateButton = document.querySelector('.bpx-player-ctrl-btn.bpx-player-ctrl-playbackrate');
-    const controlBar = nativeRateButton && nativeRateButton.parentElement;
-    if (!nativeRateButton || !controlBar) return;
-
     createRateUi(controlBar, nativeRateButton);
   }
 

--- a/tests/playback-controls.browser.test.cjs
+++ b/tests/playback-controls.browser.test.cjs
@@ -66,13 +66,38 @@ test('playback controls survive realistic DOM replacement', {
   await page.route('https://www.bilibili.com/**', (route) => route.fulfill({
     contentType: 'text/html',
     body: `<!doctype html>
-      <html><body>
+      <html><head>
+        <style>
+          .bpx-player-control-bottom-right {
+            align-items: flex-end;
+            display: flex;
+            height: 35px;
+          }
+          .bpx-player-ctrl-btn,
+          .fixture-control {
+            display: block;
+            height: 22px;
+            line-height: 22px;
+          }
+          @media screen and (min-width: 750px) {
+            .bpx-player-container[data-screen='web'] .bpx-player-ctrl-btn,
+            .bpx-player-container[data-screen='web'] .fixture-control,
+            .bpx-player-container[data-screen='full'] .bpx-player-ctrl-btn,
+            .bpx-player-container[data-screen='full'] .fixture-control {
+              height: 32px;
+              line-height: 32px;
+            }
+          }
+        </style>
+      </head><body>
         <div id="bilibili-player">
           <div class="bpx-player-container" data-screen="normal">
             <div class="bpx-player-video-wrap"><video></video></div>
             <div class="bpx-player-control-bottom-right">
+              <div class="fixture-control fixture-quality">1080P 高清</div>
+              <div class="fixture-control fixture-subtitle">字幕</div>
               <div class="bpx-player-ctrl-btn bpx-player-ctrl-playbackrate">倍速</div>
-              <button class="bpx-player-ctrl-wide" type="button">宽屏</button>
+              <button class="bpx-player-ctrl-wide fixture-control" type="button">宽屏</button>
             </div>
           </div>
         </div>
@@ -96,12 +121,57 @@ test('playback controls survive realistic DOM replacement', {
   await page.waitForSelector('.stepless-video-rate-btn');
   await page.waitForFunction(() => document.querySelector('video').playbackRate === 2.25);
 
+  const assertGeometry = async (screen) => {
+    await page.locator('.bpx-player-container').evaluate((element, nextScreen) => {
+      element.dataset.screen = nextScreen;
+    }, screen);
+    const geometry = await page.evaluate(() => {
+      const custom = document.querySelector('.stepless-video-rate-btn');
+      const quality = document.querySelector('.fixture-quality');
+      const subtitle = document.querySelector('.fixture-subtitle');
+      const bar = document.querySelector('.bpx-player-control-bottom-right');
+      const panel = document.querySelector('.stepless-video-rate-box');
+      const customRect = custom.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      return {
+        customTop: customRect.top,
+        qualityTop: quality.getBoundingClientRect().top,
+        subtitleTop: subtitle.getBoundingClientRect().top,
+        customBottom: customRect.bottom,
+        barBottom: bar.getBoundingClientRect().bottom,
+        panelBottom: panelRect.bottom
+      };
+    });
+    assert.ok(Math.abs(geometry.customTop - geometry.qualityTop) <= 1, `${screen}: custom rate control should align with quality control`);
+    assert.ok(Math.abs(geometry.customTop - geometry.subtitleTop) <= 1, `${screen}: custom rate control should align with subtitle control`);
+    assert.ok(geometry.customBottom <= geometry.barBottom + 1, `${screen}: custom rate control should remain inside the control bar`);
+    assert.ok(Math.abs(geometry.panelBottom - geometry.customTop) <= 1, `${screen}: rate panel should touch the trigger without a hover dead zone`);
+  };
+
   assert.equal(await page.locator('.stepless-video-rate-btn-value').textContent(), '2.25x');
+  assert.equal(await page.locator('[data-biliplus-control="stepless-video-rate"]').count(), 1);
   assert.equal(
     await page
       .locator('.bpx-player-ctrl-playbackrate:not([data-biliplus-control])')
       .evaluate((element) => getComputedStyle(element).display),
     'none',
+  );
+  await assertGeometry('normal');
+  await assertGeometry('web');
+  await assertGeometry('full');
+
+  await page.locator('.bpx-player-control-bottom-right').evaluate((bar) => {
+    bar.innerHTML = bar.innerHTML;
+  });
+  await page.waitForFunction(
+    () => document.querySelectorAll('[data-biliplus-control="stepless-video-rate"]').length === 1,
+    null,
+    { timeout: 3000 }
+  );
+  assert.equal(await page.locator('[data-biliplus-control="stepless-video-rate"]').count(), 1);
+  assert.equal(
+    await page.locator('.bpx-player-ctrl-playbackrate:not([data-biliplus-control])').count(),
+    1
   );
   assert.equal(await page.locator('.bpx-player-ctrl-wide').evaluate((element) => element.classList.contains('bpx-state-entered')), true);
 


### PR DESCRIPTION
## 问题

在 Bilibili 视频播放器中启用 BiliPlus 无级倍速后，倍速按钮与清晰度、字幕等控制项无法保持垂直对齐。倍速面板与按钮之间还存在明显空白区域，鼠标移动到面板时可能触发隐藏/显示定时器，造成闪烁。

## 修改前后效果

### 修复后

<img width="297" height="164" alt="image" src="https://github.com/user-attachments/assets/152cde80-bae9-4c54-be2c-333a322e5ec1" />


- 倍速按钮与清晰度、字幕处于同一水平基线；
- 倍速面板紧贴按钮上方；
- 控件之间没有明显空白死区。

### 修复前

<img width="235" height="150" alt="image" src="https://github.com/user-attachments/assets/8ecbc5fe-bc2d-4bd2-8449-9c4379e1a4ab" />


- 倍速文字明显低于相邻控制项；
- 倍速面板与按钮之间存在较大空隙；
- 鼠标移动到面板时可能触发闪烁。

## 根因

Bilibili 新版播放器会对 `.bpx-player-ctrl-btn` 统一设置控制项高度。BiliPlus 原有样式又额外设置了固定高度、顶部内边距，以及全屏/网页全屏下的额外高度，导致自定义倍速控件的内容基线与其他原生控制项不一致。

倍速面板原本使用固定的 `bottom` 值，与按钮之间形成鼠标命中空隙。鼠标移动到面板时会先离开根节点，从而触发延迟隐藏逻辑。

## 修改内容

- 移除自定义倍速控件上的固定高度、顶部内边距和重复行高设置，使其跟随播放器控制栏布局；
- 将面板定位改为 `bottom: 100%`，使其贴在触发按钮上方，消除 hover dead zone；
- 原生倍速按钮查询增加 `:not([data-biliplus-control="stepless-video-rate"])`，避免播放器 DOM 重建时重复识别插件自身节点；
- 增加按钮垂直对齐、面板间隙和重复挂载回归测试。

## 验证

- `node --check scripts/stepless-video-rate.js` 通过；
- `make test` 通过；
- 浏览器 E2E 测试已加入测试套件；当前环境未安装 Playwright，因此该测试被自动跳过。
